### PR TITLE
Fix export

### DIFF
--- a/pydantic_mongo/__init__.py
+++ b/pydantic_mongo/__init__.py
@@ -1,3 +1,5 @@
-from .abstract_repository import AbstractRepository  # noqa
-from .fields import ObjectIdField  # noqa
-from .version import __version__  # noqa
+from .abstract_repository import AbstractRepository
+from .fields import ObjectIdField
+from .version import __version__  # noqa: F401
+
+__all__ = ["ObjectIdField", "AbstractRepository"]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,5 @@
 mock
+setuptools==69.0.3
 coverage==7.4.0
 flake8==6.1.0
 phulpy==1.0.10


### PR DESCRIPTION
Pylance is crying that AbstractRepository and ObjectIdField are not exported.

adding them to __all__ fixed the problem.

also, couldn't test it on my system as there's a subdependency missing (setuptools). added it