### PR TITLE
Added json mode argument on model_dump call.

### DIFF
--- a/pydantic_mongo/abstract_repository.py
+++ b/pydantic_mongo/abstract_repository.py
@@ -70,7 +70,7 @@ class AbstractRepository(Generic[T]):
         :return: dict
         """
         model_with_id = cast(ModelWithId, model)
-        data = model_with_id.model_dump()
+        data = model_with_id.model_dump(mode='json')
         data.pop("id")
         if model_with_id.id:
             data["_id"] = model_with_id.id


### PR DESCRIPTION
bson has problems serializing pydantic models with Enum derived classes. Calling model_dump with mode='json' solves the issue.