### PR TITLE
search for 'id' field also in model_computed_fields

### DIFF
--- a/pydantic_mongo/abstract_repository.py
+++ b/pydantic_mongo/abstract_repository.py
@@ -57,7 +57,8 @@ class AbstractRepository(Generic[T]):
         return self.__database[self.__collection_name]
 
     def __validate(self):
-        if "id" not in self.__document_class.model_fields:
+        if "id" not in self.__document_class.model_fields and \
+            "id" not in self.__document_class.model_computed_fields:
             raise Exception("Document class should have id field")
         if not self.__collection_name:
             raise Exception("Meta should contain collection name")


### PR DESCRIPTION
Allow computed `id` fields.

Since the `AbstractRepository` requires the  document_class to have an `id` field I
had problems with id as a computed_field.

This PR allows to use document classes where the `id` is computed, for example:

```python
class Spam(BaseModel):  
    
    @computed_field
    @property
    def id(self) -> str:
        return self.some_unique_attribute

    some_unique_attribute: str
```