### PR TITLE
fix: Fix pagination when sorting by id

### DIFF
--- a/pydantic_mongo/base_abstract_repository.py
+++ b/pydantic_mongo/base_abstract_repository.py
@@ -1,6 +1,7 @@
 from typing import Any, Generic, Optional, Sequence, Tuple, Type, TypeVar, cast
 
 from pydantic import BaseModel
+from bson import ObjectId
 
 from .pagination import decode_pagination_cursor
 
@@ -104,7 +105,7 @@ class BaseAbstractRepository(Generic[T]):
                 else:
                     compare_operator = "$lt" if sort_expression[1] > 0 else "$gt"
                 dict_values.append(
-                    (sort_expression[0], {compare_operator: cursor_data[i]})
+                    (sort_expression[0], {compare_operator: cursor_data[i] if sort_expression[0] != '_id' else ObjectId(cursor_data[i])})
                 )
             generated_query["$and"].append(dict(dict_values))
 


### PR DESCRIPTION
Mongo expressions using '_id' works a bit differently from others field, one cannot put a  '$gt': 'string' but need to put an ObjectId instead: '$gt': oid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pagination query handling to ensure that sorting by the default identifier now processes values in a consistent and accurate manner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->